### PR TITLE
Add possibility to configure currentDirectory aka "directory" for supervisor config

### DIFF
--- a/Sources/PerfectFlock.swift
+++ b/Sources/PerfectFlock.swift
@@ -17,12 +17,12 @@ public extension Config {
 let perfect = "perfect"
 
 class PerfectSupervisorProvder: SupervisordProvider {
-    
+
     static var argumentString = ""
-    
+
     let name = perfect
     let programName = perfect
-    
+
     func confFileContents(for server: Server) -> String {
         var commandComponents = [Paths.executable]
         if let ssl = Config.ssl {
@@ -53,17 +53,18 @@ class PerfectSupervisorProvder: SupervisordProvider {
             "autorestart=unexpected",
             "stdout_logfile=\(Config.outputLog)",
             "stderr_logfile=\(Config.errorLog)",
+            "directory=\(Paths.currentDirectory)",
             ""
         ].joined(separator: "\n")
     }
-    
+
 }
 
 public class ToolsTask: Task {
     public let name = "tools"
     public let namespace = perfect
     public let hookTimes: [HookTime] = [.after("tools:dependencies")]
-    
+
     public func run(on server: Server) throws {
         print("Installing Perfect dependencies")
         try server.execute("sudo apt-get -qq install openssl libssl-dev uuid-dev")


### PR DESCRIPTION
Hi Jake!
Love your PerfectFlock Integration. One thing I noticed: My perfect application gives me weird errors
`fileError(2, "No such file or directory /Users/krystof/git/perfect-blog/Packages/PerfectLib-2.0.9/Sources/PerfectLib/File.swift open(_:permissions:) 244` if i don't set the currentDirectory to the project directory.

This seems to be a perfect issue, they seem to need you to run the HTTP-Server App from the project directory. I didn't have to set the directory for my vapor app. Nevertheless, would be nice if you merge this.